### PR TITLE
fix bug causing errors when command buffer is resized 

### DIFF
--- a/src/redis-fast-driver.cc
+++ b/src/redis-fast-driver.cc
@@ -279,7 +279,7 @@ NAN_METHOD(RedisConnector::RedisCmd) {
 			//increase buf size
 			//LOG("buf needed %zu\n", bufused + len);
 			//LOG("bufsize is not big enough, current: %zu ", bufsize);
-			bufsize = ((bufused + len) / 256 + 1) * 256;
+			bufsize = bufsize * 2;
 			//LOG("increase it to %zu\n", bufsize);
 			buf = (char*)realloc(buf, bufsize);
 			//try the smae index again

--- a/src/redis-fast-driver.cc
+++ b/src/redis-fast-driver.cc
@@ -271,11 +271,16 @@ NAN_METHOD(RedisConnector::RedisCmd) {
 	for(uint32_t i=0;i<arraylen;i++) {
 		String::Utf8Value str(array->Get(i));
 		uint32_t len = str.length();
+		//LOG("i %u\n", i);
+		//LOG("str: \"%s\"\n", *str);
+		//LOG("len %u\n", len);
+		//LOG("bufused %zu\n", bufused);
 		if(bufused + len > bufsize) {
 			//increase buf size
-			// LOG("bufsize is not big enough, current: %llu ", bufsize);
+			//LOG("buf needed %zu\n", bufused + len);
+			//LOG("bufsize is not big enough, current: %zu ", bufsize);
 			bufsize = ((bufused + len) / 256 + 1) * 256;
-			// LOG("increase it to %llu\n", bufsize);
+			//LOG("increase it to %zu\n", bufsize);
 			buf = (char*)realloc(buf, bufsize);
 			bufused = 0;
 			i = -1;
@@ -285,9 +290,10 @@ NAN_METHOD(RedisConnector::RedisCmd) {
 		memcpy(buf+bufused, *str, len);
 		bufused += len;
 		argvlen[i] = len;
-		//LOG("add \"%s\" len: %d\n", argv[i], argvlen[i]);
+		//LOG("added \"%.*s\" len: %zu\n", int(argvlen[i]), argv[i], argvlen[i]);
 	}
 	
+	//LOG("command buffer filled with: \"%.*s\"\n", int(bufused), argv[0]);
 	uint32_t callback_id = self->callback_id++;
 	Isolate* isolate = Isolate::GetCurrent();
 	self->callbacksMap[callback_id].Reset(isolate, Local<Function>::Cast(info[1]));

--- a/src/redis-fast-driver.cc
+++ b/src/redis-fast-driver.cc
@@ -282,8 +282,8 @@ NAN_METHOD(RedisConnector::RedisCmd) {
 			bufsize = ((bufused + len) / 256 + 1) * 256;
 			//LOG("increase it to %zu\n", bufsize);
 			buf = (char*)realloc(buf, bufsize);
-			bufused = 0;
-			i = -1;
+			//try the smae index again
+			i--;
 			continue;
 		}
 		argv[i] = buf + bufused;

--- a/src/redis-fast-driver.cc
+++ b/src/redis-fast-driver.cc
@@ -259,9 +259,17 @@ NAN_METHOD(RedisConnector::RedisCmd) {
 	// Local<Function> cb = Local<Function>::Cast(info[1]);
 	//Persistent<Function> cb = Persistent<Function>::New(Local<Function>::Cast(args[1]));
 	size_t arraylen = array->Length();
+
+	bool resize_arraylen = false;
+
 	while(arraylen > argvroom) {
-		// LOG("double room for argv %zu\n", argvroom);
+		//LOG("double room for argv %zu\n", argvroom);
 		argvroom *= 2;
+		resize_arraylen = true;
+	}
+
+	if (resize_arraylen) {
+		//LOG("resizing argvlen/argv");
 		free(argvlen);
 		free(argv);
 		argvlen = (size_t*)malloc(argvroom * sizeof(size_t*));

--- a/src/redis-fast-driver.cc
+++ b/src/redis-fast-driver.cc
@@ -241,7 +241,7 @@ void RedisConnector::OnRedisResponse(redisAsyncContext *c, void *r, void *privda
 
 NAN_METHOD(RedisConnector::RedisCmd) {
 	//LOG("%s\n", __PRETTY_FUNCTION__);
-	static size_t bufsize = 4096;
+	static size_t bufsize = RFD_COMMAND_BUFFER_SIZE;
 	static char* buf = (char*)malloc(bufsize);
 	static size_t argvroom = 128;
 	static size_t *argvlen = (size_t*)malloc(argvroom * sizeof(size_t*));

--- a/src/redis-fast-driver.cc
+++ b/src/redis-fast-driver.cc
@@ -278,7 +278,7 @@ NAN_METHOD(RedisConnector::RedisCmd) {
 			// LOG("increase it to %llu\n", bufsize);
 			buf = (char*)realloc(buf, bufsize);
 			bufused = 0;
-			i = 0;
+			i = -1;
 			continue;
 		}
 		argv[i] = buf + bufused;

--- a/src/redis-fast-driver.h
+++ b/src/redis-fast-driver.h
@@ -3,6 +3,8 @@
 
 #include <nan.h>
 
+#define RFD_COMMAND_BUFFER_SIZE 4096;
+
 #if ENABLELOG
 #define LOG(...) fprintf( stderr, __VA_ARGS__ );
 #else

--- a/test/driverSpec.js
+++ b/test/driverSpec.js
@@ -201,6 +201,8 @@ describe('redis-fast-driver', function() {
     });
 
     it('works correctly when command buffer needs to be resized', async function() {
+      // This should be the same as RFD_COMMAND_BUFFER_SIZE defined in
+      // redis-fast-driver.h
       const commandBufferSize = 4096;
       const expectedResult = [];
       const getCommand = [ 'mget' ];


### PR DESCRIPTION
and some other improvements ( see individual commits )

the bug must have been introduced in b7cebab75f221b22177236eb3f09ad29cdc833fb

let me know if you are unhappy with any of the commits and I can remove them. I guess you might object to 3e6d28c2ac4b5dd85d67bfd6419b571fe1dc3905 given that you have used the doubling strategy in the past and opted to change it, but the current one leads to far too many reallocations when you need to send a command greatly exceeding current size of the buffer. 